### PR TITLE
Update example to not user profile.id

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ accepts these credentials and calls `done` providing a user, as well as
         callbackURL: "http://127.0.0.1:3000/auth/bitbucket/callback"
       },
       function(token, tokenSecret, profile, done) {
-        User.findOrCreate({ bitbucketId: profile.id }, function (err, user) {
+        User.findOrCreate({ bitbucketId: profile.username }, function (err, user) {
           return done(err, user);
         });
       }


### PR DESCRIPTION
Bitbucket does not pass back an `id` property on its profile, rather, it's probably best to use the `username` property.

Here is an example of what I get back for the `profile` value in the strategy callback:

```
{ 
  provider: 'bitbucket',
  username: 'jacob4u2',
  displayName: 'Jacob Gable',
  name: { familyName: 'Gable', givenName: 'Jacob' },
  _raw: '<some long json string>',
  _json: {
    repositories: [<Repos>],
    user: {
      username: 'jacob4u2',
      first_name: 'Jacob',
      last_name: 'Gable',
      is_team: false,
      avatar: 'https://secure.gravatar.com/avatar/2ed341e37f2c3ef44296019c9e9829bf?d=https%3A%2F%2Fdwz7u9t8u8usb.cloudfront.net%2Fm%2F309704b5e60d%2Fimg%2Fdefault_avatar%2F32%2Fuser_blue.png&s=32',
      resource_uri: '/1.0/users/jacob4u2'
    }
}
```
