### PR TITLE
Add support for emails

### DIFF
--- a/lib/passport-bitbucket/strategy.js
+++ b/lib/passport-bitbucket/strategy.js
@@ -1,7 +1,8 @@
 /**
  * Module dependencies.
  */
-var util = require('util')
+var _ = require('underscore')
+  , util = require('util')
   , OAuthStrategy = require('passport-oauth').OAuthStrategy
   , InternalOAuthError = require('passport-oauth').InternalOAuthError;
 
@@ -70,22 +71,37 @@ util.inherits(Strategy, OAuthStrategy);
  * @api protected
  */
 Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
+  var that = this;
   this._oauth.get('https://api.bitbucket.org/1.0/user/', token, tokenSecret, function (err, body, res) {
     if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
     
     try {
-      var json = JSON.parse(body);
+      var json_profile = JSON.parse(body);
       
       var profile = { provider: 'bitbucket' };
-      profile.username = json.user.username;
-      profile.displayName = json.user.first_name + ' ' + json.user.last_name;
-      profile.name = { familyName: json.user.last_name,
-                       givenName: json.user.first_name };
-                       
+      profile.username = json_profile.user.username;
+      profile.displayName = json_profile.user.first_name + ' ' + json_profile.user.last_name;
+      profile.name = { familyName: json_profile.user.last_name,
+                       givenName: json_profile.user.first_name };
       profile._raw = body;
-      profile._json = json;
-      
-      done(null, profile);
+      profile._json = json_profile;
+
+      // Get emails
+      that._oauth.get('https://api.bitbucket.org/1.0/users/'+profile.username+'/emails', token, tokenSecret, function (err, body, res) {
+        if (err) { return done(new InternalOAuthError('failed to fetch user emails', err)); }
+        
+        try {
+          var emails = JSON.parse(body);
+          profile.emails = _.map(emails, function(emailInfo) {
+            return {
+              value: emailInfo.email
+            }
+          });
+          done(null, profile);
+        } catch(e) {
+          done(e);
+        }
+      });
     } catch(e) {
       done(e);
     }

--- a/lib/passport-bitbucket/strategy.js
+++ b/lib/passport-bitbucket/strategy.js
@@ -93,6 +93,9 @@ Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
         try {
           var emails = JSON.parse(body);
           profile.emails = _.map(emails, function(emailInfo) {
+            if (!emailInfo.email) {
+              return done(new InternalOAuthError('Invalid emails:', emailInfo));
+            }
             return {
               value: emailInfo.email
             }

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "underscore": "1.4.4"
   },
   "devDependencies": {
-    "vows": "0.6.x"
+    "vows": "0.7.0"
   },
   "scripts": {
-    "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"
+    "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js --spec"
   },
   "engines": { "node": ">= 0.4.0" },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "main": "./lib/passport-bitbucket",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth": "0.1.x",
+    "underscore": "1.4.4"
   },
   "devDependencies": {
     "vows": "0.6.x"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-bitbucket",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Bitbucket authentication strategy for Passport.",
   "keywords": ["passport", "bitbucket", "auth", "authn", "authentication", "identity"],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -31,5 +31,11 @@
   "scripts": {
     "test": "NODE_PATH=lib node_modules/.bin/vows test/*-test.js"
   },
-  "engines": { "node": ">= 0.4.0" }
+  "engines": { "node": ">= 0.4.0" },
+  "contributors": [
+      {
+          "name": "Samy Pesse",
+          "email": "samypesse@gmail.com"
+      }
+  ]
 }

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -3,9 +3,7 @@ var assert = require('assert');
 var util = require('util');
 var bitbucket = require('passport-bitbucket');
 
-
 vows.describe('passport-bitbucket').addBatch({
-  
   'module': {
     'should report a version': function (x) {
       assert.isString(bitbucket.version);

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -99,6 +99,16 @@ vows.describe('BitbucketStrategy').addBatch({
                 "resource_uri": "/1.0/users/jaredhanson" \
             } \
         }';
+
+        if (url == "https://api.bitbucket.org/1.0/users/jaredhanson/emails") {
+          body = JSON.stringify([
+            {
+              "active": true,
+              "email": "jaredhanson@gmail.com",
+              "primary": true
+            }
+          ]);
+        }
         
         callback(null, body, undefined);
       }
@@ -127,6 +137,7 @@ vows.describe('BitbucketStrategy').addBatch({
         assert.equal(profile.displayName, 'Jared Hanson');
         assert.equal(profile.name.familyName, 'Hanson');
         assert.equal(profile.name.givenName, 'Jared');
+        assert.equal(profile.emails[0].value, 'jaredhanson@gmail.com');
       },
       'should set raw property' : function(err, profile) {
         assert.isString(profile._raw);


### PR DESCRIPTION
This PR adds "emails" to the profile suing BitBucket API: https://confluence.atlassian.com/display/BITBUCKET/emails+Resource#emailsResource-GETalistofuser'semailaddresses

It has been tested and it used on a project.
