### PR TITLE
Update to use the OAuth 2.0 APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .DS_Store
 
 # Node.js
-node_modules/*
+**/node_modules/*
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Passport-Bitbucket
 
 [Passport](https://github.com/jaredhanson/passport) strategy for authenticating
-with [Bitbucket](https://bitbucket.org/) using the OAuth 1.0a API.
+with [Bitbucket](https://bitbucket.org/) using the OAuth 2.0 API.
 
 This module lets you authenticate using Bitbucket in your Node.js applications.
 By plugging into Passport, Bitbucket authentication can be easily and
@@ -23,11 +23,11 @@ accepts these credentials and calls `done` providing a user, as well as
 `options` specifying a consumer key, consumer secret, and callback URL.
 
     passport.use(new BitbucketStrategy({
-        consumerKey: BITBUCKET_CONSUMER_KEY,
-        consumerSecret: BITBUCKET_CONSUMER_SECRET,
+        clientID: BITBUCKET_CLIENT_ID,
+        clientSecret: BITBUCKET_CLIENT_SECRET,
         callbackURL: "http://127.0.0.1:3000/auth/bitbucket/callback"
       },
-      function(token, tokenSecret, profile, done) {
+      function(accessToken, refreshToken, profile, done) {
         User.findOrCreate({ bitbucketId: profile.username }, function (err, user) {
           return done(err, user);
         });

--- a/examples/login/app.js
+++ b/examples/login/app.js
@@ -3,8 +3,8 @@ var express = require('express')
   , util = require('util')
   , BitbucketStrategy = require('passport-bitbucket').Strategy;
 
-var BITBUCKET_CONSUMER_KEY = "--insert-bitbucket-consumer-key-here--"
-var BITBUCKET_CONSUMER_SECRET = "--insert-bitbucket-consumer-secret-here--";
+var BITBUCKET_CLIENT_ID = "--insert-bitbucket-client-id-here--"
+var BITBUCKET_CLIENT_SECRET = "--insert-bitbucket-client-secret-here--";
 
 
 // Passport session setup.
@@ -28,8 +28,8 @@ passport.deserializeUser(function(obj, done) {
 //   credentials (in this case, a token, tokenSecret, and Bitbucket profile),
 //   and invoke a callback with a user object.
 passport.use(new BitbucketStrategy({
-    consumerKey: BITBUCKET_CONSUMER_KEY,
-    consumerSecret: BITBUCKET_CONSUMER_SECRET,
+    clientID: BITBUCKET_CLIENT_ID,
+    clientSecret: BITBUCKET_CLIENT_SECRET,
     callbackURL: "http://127.0.0.1:3000/auth/bitbucket/callback"
   },
   function(token, tokenSecret, profile, done) {

--- a/examples/login/package.json
+++ b/examples/login/package.json
@@ -2,7 +2,7 @@
   "name": "passport-bitbucket-examples-login",
   "version": "0.0.0",
   "dependencies": {
-    "express": ">= 0.0.0",
+    "express": "^3.21.0",
     "ejs": ">= 0.0.0",
     "passport": ">= 0.0.0",
     "passport-bitbucket": ">= 0.0.0"

--- a/lib/passport-bitbucket/profile.js
+++ b/lib/passport-bitbucket/profile.js
@@ -1,0 +1,20 @@
+/**
+ * Parse profile.
+ *
+ * @param {Object|String} json
+ * @return {Object}
+ * @api private
+ */
+exports.parse = function(json) {
+  if ('string' == typeof json) {
+    json = JSON.parse(json);
+  }
+  
+  var profile = {};
+  profile.id = json.uuid;
+  profile.displayName = json.display_name;
+  profile.username = json.username;
+  profile.profileUrl = json.links.html.href;
+
+  return profile;
+};

--- a/lib/passport-bitbucket/strategy.js
+++ b/lib/passport-bitbucket/strategy.js
@@ -71,7 +71,6 @@ function Strategy(options, verify) {
   this.name = 'bitbucket';
   this._userProfileURL = options.userProfileURL || 'https://bitbucket.org/api/2.0/user';
   this._oauth2.useAuthorizationHeaderforGET(true);
-  console.log(this);
 }
 
 /**

--- a/lib/passport-bitbucket/strategy.js
+++ b/lib/passport-bitbucket/strategy.js
@@ -2,34 +2,39 @@
  * Module dependencies.
  */
 var util = require('util')
-  , OAuthStrategy = require('passport-oauth').OAuthStrategy
-  , InternalOAuthError = require('passport-oauth').InternalOAuthError;
+  , OAuth2Strategy = require('passport-oauth2')
+  , Profile = require('./profile')
+  , InternalOAuthError = require('passport-oauth2').InternalOAuthError;
 
 
 /**
  * `Strategy` constructor.
  *
  * The Bitbucket authentication strategy authenticates requests by delegating to
- * Bitbucket using the OAuth protocol.
+ * Bitbucket using the OAuth 2.0 protocol.
  *
- * Applications must supply a `verify` callback which accepts a `token`,
- * `tokenSecret` and service-specific `profile`, and then calls the `done`
+ * Applications must supply a `verify` callback which accepts an `accessToken`,
+ * `refreshToken` and service-specific `profile`, and then calls the `done`
  * callback supplying a `user`, which should be set to `false` if the
  * credentials are not valid.  If an exception occured, `err` should be set.
  *
  * Options:
- *   - `consumerKey`     identifies client to Bitbucket
- *   - `consumerSecret`  secret used to establish ownership of the consumer key
- *   - `callbackURL`     URL to which Bitbucket will redirect the user after obtaining authorization
+ *   - `consumerKey`     DEPRECATED, use clientID
+ *   - `consumerSecret`  DEPRECATED, use clientSecret
+ *   - `clientID`      identifies client to Bitbucket
+ *   - `clientSecret`   secret used to esablish ownership of the consumer key
+ *   - `callbackURL`      URL to which Bitbucket will redirect the user after granting authorization
+ *   - `scope`         array of permission scopes to request.  valid scopes include:
+ *                     (see https://confluence.atlassian.com/display/BITBUCKET/OAuth+on+Bitbucket#OAuthonBitbucket-Scopes for more info)
  *
  * Examples:
  *
  *     passport.use(new BitbucketStrategy({
- *         consumerKey: '123-456-789',
- *         consumerSecret: 'shhh-its-a-secret'
+ *         clientID: '123-456-789',
+ *         clientSecret: 'shhh-its-a-secret'
  *         callbackURL: 'https://www.example.net/auth/bitbucket/callback'
  *       },
- *       function(token, tokenSecret, profile, done) {
+ *       function(accessToken, refreshToken, profile, done) {
  *         User.findOrCreate(..., function (err, user) {
  *           done(err, user);
  *         });
@@ -42,55 +47,76 @@ var util = require('util')
  */
 function Strategy(options, verify) {
   options = options || {};
-  options.requestTokenURL = options.requestTokenURL || 'https://bitbucket.org/api/1.0/oauth/request_token/';
-  options.accessTokenURL = options.accessTokenURL || 'https://bitbucket.org/api/1.0/oauth/access_token/';
-  options.userAuthorizationURL = options.userAuthorizationURL || 'https://bitbucket.org/api/1.0/oauth/authenticate/';
-  options.sessionKey = options.sessionKey || 'oauth:bitbucket';
+  options.authorizationURL = options.authorizationURL || 'https://bitbucket.org/site/oauth2/authorize';
+  options.tokenURL = options.tokenURL || 'https://bitbucket.org/site/oauth2/access_token';
+  options.customHeaders = options.customHeaders || {};
 
-  OAuthStrategy.call(this, options, verify);
+  //HACK: swap for OAuth2 property
+  if (options.consumerKey && !options.clientID) {
+    options.clientID = options.consumerKey;
+  }
+
+  //HACK: swap for OAuth2 property
+  if (options.consumerSecret && !options.clientSecret) {
+    options.clientSecret = options.consumerSecret;
+  }
+
+  if (!options.customHeaders['User-Agent']) {
+    options.customHeaders['User-Agent'] = options.userAgent || 'passport-bitbucket';
+    //HACK: requests need to fall back to Basic Auth (for access_token call)
+    options.customHeaders.Authorization = 'Basic ' + new Buffer(options.clientID + ':' + options.clientSecret).toString('base64');
+  }
+
+  OAuth2Strategy.call(this, options, verify);
   this.name = 'bitbucket';
+  this._userProfileURL = options.userProfileURL || 'https://bitbucket.org/api/2.0/user';
+  this._oauth2.useAuthorizationHeaderforGET(true);
+  console.log(this);
 }
 
 /**
- * Inherit from `OAuthStrategy`.
+ * Inherit from `OAuth2Strategy`.
  */
-util.inherits(Strategy, OAuthStrategy);
+util.inherits(Strategy, OAuth2Strategy);
+
 
 /**
  * Retrieve user profile from Bitbucket.
  *
  * This function constructs a normalized profile, with the following properties:
  *
- *   - `displayName`
+ *   - `provider`         always set to `bitbucket`
+ *   - `id`               the user's Bitbucket uuid
+ *   - `username`         the user's Bitbucket username
+ *   - `displayName`      the user's full name
+ *   - `profileUrl`       the URL of the profile for the user on Bitbucket
  *
- * @param {String} token
- * @param {String} tokenSecret
- * @param {Object} params
+ * @param {String} accessToken
  * @param {Function} done
  * @api protected
  */
-Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
-  this._oauth.get('https://api.bitbucket.org/1.0/user/', token, tokenSecret, function (err, body, res) {
-    if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
+Strategy.prototype.userProfile = function(accessToken, done) {
+  this._oauth2.get(this._userProfileURL, accessToken, function (err, body, res) {
+    var json;
+    
+    if (err) {
+      return done(new InternalOAuthError('Failed to fetch user profile', err));
+    }
     
     try {
-      var json = JSON.parse(body);
-      
-      var profile = { provider: 'bitbucket' };
-      profile.username = json.user.username;
-      profile.displayName = json.user.first_name + ' ' + json.user.last_name;
-      profile.name = { familyName: json.user.last_name,
-                       givenName: json.user.first_name };
-                       
-      profile._raw = body;
-      profile._json = json;
-      
-      done(null, profile);
-    } catch(e) {
-      done(e);
+      json = JSON.parse(body);
+    } catch (ex) {
+      return done(new Error('Failed to parse user profile'));
     }
+    
+    var profile = Profile.parse(json);
+    profile.provider  = 'bitbucket';
+    profile._raw = body;
+    profile._json = json;
+    
+    done(null, profile);
   });
-}
+};
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./lib/passport-bitbucket",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-oauth": "0.1.x"
+    "passport-oauth2": "^1.1.2"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
This will still work for https://confluence.atlassian.com/display/BITBUCKET/OAuth+on+Bitbucket#OAuthonBitbucket-OAuth2.0.

Should be an easy upgrade since the original params will still work, but the arguments to the callback function have changed (to the OAuth2 variant).

Will need a semver version bump to indicate the change.